### PR TITLE
Fix crash on undefined default when there are no errors.

### DIFF
--- a/lib/Dancer2/Plugin/DataTransposeValidator/Validator.pm
+++ b/lib/Dancer2/Plugin/DataTransposeValidator/Validator.pm
@@ -177,7 +177,7 @@ has errors => (
         return {} if $self->valid;
 
         my $errors_hash = $self->errors_hash || '';
-        my $ret;
+        my $ret = {};
         my $dtv_errors = $self->_dtv->errors_hash;
         while ( my ( $key, $value ) = each %$dtv_errors ) {
             my @errors = map { $_->{value} } @{$value};


### PR DESCRIPTION
The errors definition says "HashRef" but the implementation allows undef.